### PR TITLE
Invoke 'UpdateConfigNANDSavegame' command after writing EULAs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ CFLAGS	:=	-g -Wall -Wextra -O2 -mword-relocations \
 
 revision := $(shell git describe --tags --match v[0-9]* --abbrev=8 | sed 's/-[0-9]*-g/-/')
 
-CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS -D_GNU_SOURCE -DTITLE="\"$(APP_TITLE)\"" -DAUTHOR="\"$(APP_AUTHOR)\""
+CFLAGS	+=	$(INCLUDE) -D__3DS__ -D_GNU_SOURCE -DTITLE="\"$(APP_TITLE)\"" -DAUTHOR="\"$(APP_AUTHOR)\""
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 

--- a/source/main.c
+++ b/source/main.c
@@ -44,12 +44,15 @@ int main(int argc, char* argv[])
     res = CFGU_GetConfigInfoBlk2(4, 0xD0000, eulaData);
     if (R_FAILED(res))
     {
-        printf("Something weird happened. Couldn't get EULA data.\n\nPress Start to exit.");
+        printf("Something went wrong... Failed to get EULA data.\n\n");
         done = true;
     }
 
+    const char *do_what = eulaData[0] == 0xFF && eulaData[1] == 0xFF ? "unset" : "set";
     if(!done)
-        printf(eulaData[0] == 0xFF && eulaData[1] == 0xFF ? "Press A to unset the 3DS EULAs.\n\n" : "Press A to set the 3DS EULAs.\n\n");
+        printf("Press A to %s the 3DS EULAs.\n\n", do_what);
+
+    printf("Press START to exit.\nPress SELECT to exit & remove this application.\n\n");
 
     while(aptMainLoop())
     {
@@ -61,12 +64,26 @@ int main(int argc, char* argv[])
                 eulaData[0] = eulaData[1] = 0x00;
             else // Anything else: EULAs have not been set, so set them.
                 eulaData[0] = eulaData[1] = 0xFF;
+
+            printf("\e[5A\e[J"); // Erase the last 5 lines printed in the console
+
             res = CFG_SetConfigInfoBlk8(4, 0xD0000, eulaData);
             if(R_FAILED(res))
-                printf("Something went wrong...\n\n");
+                printf("Something went wrong... Failed to %s EULAs.\n\n", do_what);
             else
-                printf(eulaData[0] == 0xFF ? "Setting the EULA succeeded.\n\n" : "Unsetting the EULA succeeded.\n\n");
-            printf("Press START to exit.\nPress Select to exit + remove application.\n");
+            {
+                res = CFG_UpdateConfigSavegame();
+                if (R_SUCCEEDED(res))
+                    printf("Success! EULAs have been %s.\n\n", do_what);
+                else
+                    printf("EULAs have been %s, but a save error occurred.\n\n"
+                           "This should still take effect, but may not\n"
+                           "persist after the system is powered off.\n"
+                           "You can try and adjust the screen brightness\n"
+                           "settings in the HOME Menu right now to force\n"
+                           "the new EULAs to save properly.\n\n", do_what);
+            }
+            printf("Press START to exit.\nPress SELECT to exit & remove this application.\n\n");
             done = true;
         }
         if (kDown & KEY_START)

--- a/source/main.c
+++ b/source/main.c
@@ -96,6 +96,10 @@ int main(int argc, char* argv[])
             svcSleepThread(SLEEPTIME);
             break;
         }
+
+        gfxFlushBuffers();
+        gfxSwapBuffers();
+        gspWaitForVBlank();
     }
 
     aptExit();


### PR DESCRIPTION
Code changes:
- Fixes compilation with libctru >= 2.1. _(At the moment the cia build is untested)_
- DSES will now update the config savegame after (un-)setting the 3DS EULAs. Closes #1 and #2.
- Fixes the HOME and POWER buttons not responding.
- Made some text adjustments.

Explanation:

The original [EULASetter](https://github.com/SciresM/EULASetter) source code refers to a libctru function named `CFG_UpdateConfigNANDSavegame`, which has been [renamed](https://github.com/devkitPro/libctru/commit/25123ba0571618c670d62471dfe01010aa7f9bfc#diff-c5d05ffe1686feef4f4f2519b826e20fbf873c499d49cc734b4161df56b190ffL218) to `CFG_UpdateConfigSavegame` since libctru 1.4.0 (or so). This function invokes a CFG service [command](https://www.3dbrew.org/wiki/Cfg:UpdateConfigNANDSavegame) of the same name. Without it, changes to the EULAs made in DSES are only made in memory and may be lost after the system reboots or is powered off.